### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/tianxiao5450553/34deebaa-a4a6-44de-859a-b85addf127d4/295632c9-806d-4459-a164-3371bec00d5c/_apis/work/boardbadge/310fb0d7-ec7f-42dd-95d0-271da95322fd)](https://dev.azure.com/tianxiao5450553/34deebaa-a4a6-44de-859a-b85addf127d4/_boards/board/t/295632c9-806d-4459-a164-3371bec00d5c/Microsoft.RequirementCategory)
 <h1 align="center">
   <p align="center">Docusaurus</p>
   <a href="https://docusaurus.io"><img src="https://docusaurus.io/img/slash-introducing.svg" alt="Docusaurus"></a>


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/tianxiao5450553/34deebaa-a4a6-44de-859a-b85addf127d4/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.